### PR TITLE
feat: Add auto-attach project support via `AUTO_ATTACH_PUBSUB_PROJECTS` env-var

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+webapp/node_modules
+
+webapp/package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,11 @@ RUN npm run build
 
 FROM nginx:stable-alpine-slim AS serve
 COPY scripts/docker/docker_nginx.conf /etc/nginx/conf.d/default.conf
+COPY scripts/docker/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 
 WORKDIR /usr/share/nginx/html
 COPY --from=build /app/dist/webapp/browser .
 EXPOSE 80
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/scripts/docker/docker-entrypoint.sh
+++ b/scripts/docker/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 # Update runtime variables
 envsubst '${AUTO_ATTACH_PUBSUB_PROJECTS}' < /usr/share/nginx/html/index.html > /usr/share/nginx/html/index.html.tmp
-mv /usr/share/nginx/html/index.html.tmp /usr/share/nginx/html/index.html
+envsubst '${DEFAULT_PUBSUB_EMULATOR_HOST}' < /usr/share/nginx/html/index.html.tmp > /usr/share/nginx/html/index.html
 
 # Start nginx
 exec nginx -g 'daemon off;'

--- a/scripts/docker/docker-entrypoint.sh
+++ b/scripts/docker/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Update runtime variables
+envsubst '${AUTO_ATTACH_PUBSUB_PROJECTS}' < /usr/share/nginx/html/index.html > /usr/share/nginx/html/index.html.tmp
+mv /usr/share/nginx/html/index.html.tmp /usr/share/nginx/html/index.html
+
+# Start nginx
+exec nginx -g 'daemon off;'

--- a/webapp/src/app/services/pubsub.service.ts
+++ b/webapp/src/app/services/pubsub.service.ts
@@ -38,6 +38,10 @@ export class PubsubService {
       defaultHost = "http://localhost:8681"
     }
 
+    if (!defaultHost.match(/^http[s]?:\/\//)) {
+      defaultHost = `http://${defaultHost}`
+    }
+
     const prevHost = localStorage.getItem("host")
     if (prevHost) {
       console.log('loaded previous host', prevHost)

--- a/webapp/src/index.html
+++ b/webapp/src/index.html
@@ -15,6 +15,12 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link href="http://fonts.cdnfonts.com/css/cascadia-code" rel="stylesheet">
 
+  <script>
+    // Runtime configuration injected by Docker entrypoint
+    window.APP_CONFIG = {
+      autoAttachPubsubProjects: '${AUTO_ATTACH_PUBSUB_PROJECTS}'
+    };
+  </script>
 </head>
 <body class="mat-app-background">
   <app-root></app-root>

--- a/webapp/src/index.html
+++ b/webapp/src/index.html
@@ -16,9 +16,9 @@
   <link href="http://fonts.cdnfonts.com/css/cascadia-code" rel="stylesheet">
 
   <script>
-    // Runtime configuration injected by Docker entrypoint
     window.APP_CONFIG = {
-      autoAttachPubsubProjects: '${AUTO_ATTACH_PUBSUB_PROJECTS}'
+      autoAttachPubsubProjects: '${AUTO_ATTACH_PUBSUB_PROJECTS}',
+      defaultPubsubEmulatorHost: '${DEFAULT_PUBSUB_EMULATOR_HOST}'
     };
   </script>
 </head>


### PR DESCRIPTION
A simple change to add a bit more bootstrap configurability to the UI.

Tested locally by editing the value directly via editing the `APP_CONFIG` value in: webapp/src/index.html

Tested for _Docker_ via the following:
```bash
docker build -t pubsub-emulator-ui:latest --no-cache --pull --progress=plain .
docker run -p 4200:80 -e AUTO_ATTACH_PUBSUB_PROJECTS=foo,bar pubsub-emulator-ui:latest
```