### PR TITLE
feat: Add runtime configuration support for default host and auto-attach projects

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+webapp/node_modules
+
+webapp/package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,11 @@ RUN npm run build
 
 FROM nginx:stable-alpine-slim AS serve
 COPY scripts/docker/docker_nginx.conf /etc/nginx/conf.d/default.conf
+COPY scripts/docker/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 
 WORKDIR /usr/share/nginx/html
 COPY --from=build /app/dist/webapp/browser .
 EXPOSE 80
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/scripts/docker/docker-entrypoint.sh
+++ b/scripts/docker/docker-entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 # Update runtime variables
 envsubst '${AUTO_ATTACH_PUBSUB_PROJECTS}' < /usr/share/nginx/html/index.html > /usr/share/nginx/html/index.html.tmp
-mv /usr/share/nginx/html/index.html.tmp /usr/share/nginx/html/index.html
+envsubst '${DEFAULT_PUBSUB_EMULATOR_HOST}' < /usr/share/nginx/html/index.html.tmp > /usr/share/nginx/html/index.html
 
 # Start nginx
 exec nginx -g 'daemon off;'

--- a/scripts/docker/docker-entrypoint.sh
+++ b/scripts/docker/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+# Update runtime variables
+envsubst '${AUTO_ATTACH_PUBSUB_PROJECTS}' < /usr/share/nginx/html/index.html > /usr/share/nginx/html/index.html.tmp
+mv /usr/share/nginx/html/index.html.tmp /usr/share/nginx/html/index.html
+
+# Start nginx
+exec nginx -g 'daemon off;'

--- a/webapp/src/app/services/pubsub.service.ts
+++ b/webapp/src/app/services/pubsub.service.ts
@@ -38,6 +38,10 @@ export class PubsubService {
       defaultHost = "http://localhost:8681"
     }
 
+    if (!defaultHost.match(/^http[s]?:\/\//)) {
+      defaultHost = `http://${defaultHost}`
+    }
+
     const prevHost = localStorage.getItem("host")
     if (prevHost) {
       console.log('loaded previous host', prevHost)

--- a/webapp/src/index.html
+++ b/webapp/src/index.html
@@ -15,6 +15,12 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link href="http://fonts.cdnfonts.com/css/cascadia-code" rel="stylesheet">
 
+  <script>
+    // Runtime configuration injected by Docker entrypoint
+    window.APP_CONFIG = {
+      autoAttachPubsubProjects: '${AUTO_ATTACH_PUBSUB_PROJECTS}'
+    };
+  </script>
 </head>
 <body class="mat-app-background">
   <app-root></app-root>

--- a/webapp/src/index.html
+++ b/webapp/src/index.html
@@ -16,9 +16,9 @@
   <link href="http://fonts.cdnfonts.com/css/cascadia-code" rel="stylesheet">
 
   <script>
-    // Runtime configuration injected by Docker entrypoint
     window.APP_CONFIG = {
-      autoAttachPubsubProjects: '${AUTO_ATTACH_PUBSUB_PROJECTS}'
+      autoAttachPubsubProjects: '${AUTO_ATTACH_PUBSUB_PROJECTS}',
+      defaultPubsubEmulatorHost: '${DEFAULT_PUBSUB_EMULATOR_HOST}'
     };
   </script>
 </head>


### PR DESCRIPTION
This PR introduces two new environment variable configurations for the PubSub Emulator UI, making it more flexible for containerized deployments:

1. Auto-Attach Projects (`AUTO_ATTACH_PUBSUB_PROJECTS`)

- Commit: 2e0ed4e - feat: Add auto-attach project support via `AUTO_ATTACH_PUBSUB_PROJECTS` env-var
- Adds support for automatically attaching GCP projects on startup via the `AUTO_ATTACH_PUBSUB_PROJECTS` environment variable
- Projects are specified as a comma-separated list and merged idempotently with existing localStorage projects
- Implemented via a custom Docker entrypoint script that uses `envsubst` to inject runtime configuration into the Angular app through window.APP_CONFIG
- Added .dockerignore to optimize Docker builds

2. Configurable Default Host (`DEFAULT_PUBSUB_EMULATOR_HOST`)

- Commit: 3fb2391 - feat: Add configurable default-host support via `DEFAULT_PUBSUB_EMULATOR_HOST` env-var + clean-up
- Adds support for setting a default PubSub emulator host via the `DEFAULT_PUBSUB_EMULATOR_HOST` environment variable
- Falls back to: `"http://localhost:8681"` if not specified
- Updated Docker entrypoint to support both environment variables
- Code cleanup: improved variable naming and removed unnecessary whitespace checks

3. Protocol Auto-Prefix Fix

- Commit: 331d7d0 - fix: Auto-prefix the default-host with `"http://"` if it is missing the protocol
- Automatically prepends http:// to the default host if no protocol is specified
- Prevents connection errors when users provide host addresses without the protocol prefix

**Technical Implementation**

All runtime configuration is injected through a Docker entrypoint script that uses envsubst to replace template variables in index.html, making these values available to the Angular app via `window.APP_CONFIG` object.