### PR TITLE
feat: persist message attributes per topic with JSON editing

### DIFF
--- a/webapp/src/app/components/topic-details/attribute-editor/attribute-editor.component.html
+++ b/webapp/src/app/components/topic-details/attribute-editor/attribute-editor.component.html
@@ -1,7 +1,13 @@
 <mat-dialog-content>
-    <h2>Message Attributes</h2>
+    <div class="dialog-header">
+        <h2>Message Attributes</h2>
+        <button mat-stroked-button (click)="toggleJsonMode()">
+            {{ jsonMode ? 'Key-Value' : 'JSON' }}
+            <mat-icon>{{ jsonMode ? 'list' : 'data_object' }}</mat-icon>
+        </button>
+    </div>
 
-    @if(this.attributes){
+    @if(!jsonMode) {
     @for(entry of this.attributes | keyvalue; track entry.key){
     <div class="row">
         <div class="key">{{entry.key}}</div>
@@ -12,7 +18,6 @@
             </button>
         </div>
     </div>
-    }
     }
 
     <div class="new-attribute-input">
@@ -25,10 +30,20 @@
         </mat-form-field>
     </div>
     <button mat-stroked-button id="add-button" (click)="addAttribute()">Add Attribute <mat-icon>add</mat-icon></button>
+    } @else {
+    <mat-form-field appearance="outline" class="json-field">
+        <textarea matInput [formControl]="jsonInput" placeholder='{"key": "value"}'></textarea>
+    </mat-form-field>
+    @if(jsonError) {
+    <div class="json-error">Invalid JSON — must be an object with string values, e.g.
+        <code>{{ '{' }}"key": "value"{{ '}' }}</code></div>
+    }
+    }
 
 </mat-dialog-content>
 
 <mat-dialog-actions class="split-view">
     <button mat-flat-button (click)="discardChanges()">Cancel</button>
+    <button mat-stroked-button color="warn" (click)="clearAll()">Clear All <mat-icon>clear_all</mat-icon></button>
     <button mat-raised-button color="primary" (click)="saveChanges()">Save Changes</button>
 </mat-dialog-actions>

--- a/webapp/src/app/components/topic-details/attribute-editor/attribute-editor.component.scss
+++ b/webapp/src/app/components/topic-details/attribute-editor/attribute-editor.component.scss
@@ -7,8 +7,24 @@
 .row {
     display: flex;
     flex-direction: row;
-    justify-content: space-between;
     align-items: center;
+    gap: 8px;
+
+    .key {
+        flex-shrink: 0;
+        width: 40%;
+    }
+
+    .value {
+        flex: 1;
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+    }
+
+    .actions {
+        flex-shrink: 0;
+    }
 }
 
 .new-attribute-input {
@@ -24,4 +40,35 @@
     align-self: center;
     text-align: center;
     width: 100%;
+}
+
+.dialog-header {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    gap: 16px;
+}
+
+.json-field {
+    width: 100%;
+
+    textarea {
+        min-height: 160px;
+        font-family: monospace;
+        font-size: 13px;
+    }
+}
+
+.json-error {
+    color: var(--mdc-theme-error, #f44336);
+    font-size: 12px;
+    margin-top: -8px;
+    margin-bottom: 8px;
+
+    code {
+        background: rgba(0, 0, 0, 0.06);
+        padding: 1px 4px;
+        border-radius: 3px;
+    }
 }

--- a/webapp/src/app/components/topic-details/attribute-editor/attribute-editor.component.ts
+++ b/webapp/src/app/components/topic-details/attribute-editor/attribute-editor.component.ts
@@ -25,9 +25,12 @@ import { MatFormField, MatInput } from '@angular/material/input';
   styleUrl: './attribute-editor.component.scss'
 })
 export class AttributeEditorComponent {
-  public attributes: { [key: string]: string } = inject(MAT_DIALOG_DATA).attributes
+  public attributes: { [key: string]: string } = { ...inject(MAT_DIALOG_DATA).attributes }
   newKeyControl = new FormControl<string>("", Validators.required)
   newValueControl = new FormControl<string>("", Validators.required)
+  jsonMode = false
+  jsonInput = new FormControl<string>("")
+  jsonError = false
 
   constructor(
     private dialogRef: MatDialogRef<AttributeEditorComponent>
@@ -49,11 +52,55 @@ export class AttributeEditorComponent {
     }
   }
 
+  toggleJsonMode() {
+    if (!this.jsonMode) {
+      // Entering JSON mode: serialize current attributes
+      this.jsonInput.setValue(JSON.stringify(this.attributes, null, 2))
+      this.jsonError = false
+      this.jsonMode = true
+    } else {
+      // Leaving JSON mode: try to parse
+      if (this.applyJson()) {
+        this.jsonMode = false
+      }
+    }
+  }
+
+  private applyJson(): boolean {
+    try {
+      const parsed = JSON.parse(this.jsonInput.value ?? '{}')
+      if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+        this.jsonError = true
+        return false
+      }
+      for (const val of Object.values(parsed)) {
+        if (typeof val !== 'string') {
+          this.jsonError = true
+          return false
+        }
+      }
+      this.attributes = parsed
+      this.jsonError = false
+      return true
+    } catch {
+      this.jsonError = true
+      return false
+    }
+  }
+
+  clearAll() {
+    this.attributes = {}
+    this.jsonInput.setValue('{}')
+  }
+
   discardChanges() {
     this.dialogRef.close()
   }
 
   saveChanges() {
+    if (this.jsonMode) {
+      if (!this.applyJson()) return
+    }
     this.dialogRef.close(this.attributes)
   }
 }

--- a/webapp/src/app/components/topic-details/topic-details.component.html
+++ b/webapp/src/app/components/topic-details/topic-details.component.html
@@ -3,6 +3,12 @@
     <button mat-stroked-button color="accent" (click)="editAttributes()">
         Edit Attributes ({{this.attributeCount}})
     </button>
+    @if(this.attributeCount > 0) {
+    <button mat-stroked-button color="warn" (click)="clearAttributes()">
+        Clear Attributes
+        <mat-icon>clear</mat-icon>
+    </button>
+    }
     <button mat-raised-button color="primary" [disabled]="this.inputField.invalid" (click)="this.publishMessage()">
         Publish Message!
         <mat-icon>send</mat-icon>

--- a/webapp/src/app/components/topic-details/topic-details.component.ts
+++ b/webapp/src/app/components/topic-details/topic-details.component.ts
@@ -1,5 +1,5 @@
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
-import { Component, EventEmitter, inject, Input, OnInit, Output } from '@angular/core';
+import { Component, EventEmitter, inject, Input, OnChanges, OnInit, Output, SimpleChanges } from '@angular/core';
 import { ReactiveFormsModule, UntypedFormControl, Validators } from '@angular/forms';
 import { MatButton } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
@@ -9,6 +9,10 @@ import { MatInput } from '@angular/material/input';
 import { Topic } from 'src/app/services/pubsub.service';
 import { AttributeEditorComponent } from './attribute-editor/attribute-editor.component';
 
+function attributesStorageKey(topicName: string): string {
+  return `message-attributes:${topicName}`
+}
+
 @Component({
   selector: 'app-topic-details',
   templateUrl: './topic-details.component.html',
@@ -16,7 +20,7 @@ import { AttributeEditorComponent } from './attribute-editor/attribute-editor.co
   standalone: true,
   imports: [MatButton, MatIcon, MatFormField, MatInput, CdkTextareaAutosize, ReactiveFormsModule]
 })
-export class TopicDetailsComponent implements OnInit {
+export class TopicDetailsComponent implements OnInit, OnChanges {
 
   @Input() topic?: Topic
   @Output() onMessagePublish = new EventEmitter<{ topic: Topic, message: string, attributes: { [key: string]: string } }>()
@@ -28,26 +32,52 @@ export class TopicDetailsComponent implements OnInit {
   constructor() { }
 
   ngOnInit(): void {
+    this.loadAttributes()
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['topic'] && !changes['topic'].firstChange) {
+      this.loadAttributes()
+    }
+  }
+
+  private loadAttributes(): void {
+    this.attributes = {}
+    this.attributeCount = 0
+    if (!this.topic) return
+    const stored = localStorage.getItem(attributesStorageKey(this.topic.name))
+    if (stored) {
+      try {
+        this.attributes = JSON.parse(stored)
+        this.attributeCount = Object.keys(this.attributes).length
+      } catch (e) {
+        console.error('Failed to parse stored attributes for topic', this.topic?.name, e)
+      }
+    }
   }
 
   editAttributes() {
-    let dialogRef = this._dialog.open(AttributeEditorComponent, { data: { attributes: this.attributes } })
+    let dialogRef = this._dialog.open(AttributeEditorComponent, { data: { attributes: { ...this.attributes } } })
 
     dialogRef.afterClosed().subscribe(result => {
-      if (result) {
+      if (result !== undefined) {
         this.attributes = result
         this.attributeCount = Object.keys(this.attributes).length
+        localStorage.setItem(attributesStorageKey(this.topic!.name), JSON.stringify(this.attributes))
       }
     })
   }
 
-  publishMessage() {
-    console.log("this value was found", this.inputField.value)
-
-    this.onMessagePublish.emit({ topic: this.topic!, message: this.inputField.value, attributes: this.attributes })
-    this.inputField.reset()
+  clearAttributes() {
     this.attributes = {}
     this.attributeCount = 0
+    localStorage.removeItem(attributesStorageKey(this.topic!.name))
+  }
+
+  publishMessage() {
+    console.log("this value was found", this.inputField.value)
+    this.onMessagePublish.emit({ topic: this.topic!, message: this.inputField.value, attributes: this.attributes })
+    this.inputField.reset()
   }
 
 }


### PR DESCRIPTION
Several improvements to the tool related to attributes:
- Introduce the ability to cache the attributes between messages. They are stored in the browser's `localStorage` so you do not have to enter them every time when testing. They are being cached per topic.
- Introduce the possibility to specify the attributes as a json object of key-value pairs
- Introduce buttons to switch between `original` and `json` modes
- Add buttons to clear all attributes
- Fix display of long values in the attributes


<img width="530" height="509" alt="Screenshot 2026-03-19 at 15 50 55" src="https://github.com/user-attachments/assets/45b672df-efc2-439f-a462-720e2444a355" />
<img width="530" height="509" alt="Screenshot 2026-03-19 at 15 50 47" src="https://github.com/user-attachments/assets/493f2e1e-455c-456a-9547-2794967b398f" />
